### PR TITLE
History rich text option two

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,5 +32,7 @@ await startServer({
       'orderedmap',
       'rope-sequence',
       'w3c-keyname',
+
+    'diff',
   ],
 })

--- a/packages/cms/client/data.js
+++ b/packages/cms/client/data.js
@@ -40,14 +40,14 @@ export function useImageMetadata({ filename }) {
 }
 
 /**
- * @param {{ document, fieldType } & (
+ * @param {{ document, fieldType, valueForDiff } & (
 *   { op?: 'replace', path: string, value: any } |
 *   { op: 'move', from: string, path: string } |
 *   { op: 'remove', path: string }
 * )} params
 */
 export function patchDocument(params) {
- const { document, fieldType } = params
+ const { document, fieldType, valueForDiff } = params
  const { op = 'replace', path, value, from } = /** @type {typeof params & { value?: any, from?: any }} */ (params)
  // TODO: add retries if the versions do not match
  fetch(context.api.documents.single({ type: document.schema.type, id: document.id }), {
@@ -60,6 +60,7 @@ export function patchDocument(params) {
      patch: { op, path, value, from },
      userId: context.userId,
      fieldType,
+     valueForDiff,
    })
  }).catch(context.handleError)
 }

--- a/packages/cms/client/form/fields/ArrayField.js
+++ b/packages/cms/client/form/fields/ArrayField.js
@@ -58,16 +58,17 @@ export function ArrayField({ document, field, $path }) {
       document,
       fieldType: field.type,
       path: `${$path.get()}/${$valueFromDocument.get().length}`,
-      value: { _type: type, _key: crypto.randomUUID() }
+      value: { _type: type, _key: crypto.randomUUID() },
+      valueForDiff: null,
     })
   }
 
   function handleMove({ from, to }) {
-    patchDocument({ document, fieldType: field.type, from, path: to, op: 'move' })
+    patchDocument({ document, fieldType: field.type, from, path: to, op: 'move', valueForDiff: null })
   }
 
   function handleDelete({ path }) {
-    patchDocument({ document, fieldType: field.type, path, op: 'remove' })
+    patchDocument({ document, fieldType: field.type, path, op: 'remove', valueForDiff: null })
   }
 }
 

--- a/packages/cms/client/form/fields/useFieldValue.js
+++ b/packages/cms/client/form/fields/useFieldValue.js
@@ -2,6 +2,7 @@ import { patchDocument } from '#cms/client/data.js'
 import { debounce } from '#cms/client/machinery/debounce.js'
 import { useCombined } from '#ui/hooks.js'
 import { getAtPath } from './utils.js'
+/** @import { Signal } from '#ui/signal.js' */
 
 // TODO: think: if we don't send updates to ourselves, we don't need to check for dirtyness
 // - maybe useFieldValue is used in other places as well. We like the reactivity from the server,
@@ -22,10 +23,15 @@ export function useFieldValue({
   const patchDocumentDebounced = debounce(patchDocument, 300)
 
   // This signal only updates when it has seen the current local value
-  const $value = $valueFromDocument.derive((valueFromDocument, oldValueFromDocument) => {
-    if (compareValues(localValue, valueFromDocument)) dirty = false
-    return dirty ? oldValueFromDocument : valueFromDocument
-  })
+  const $value = useConditionalDerive(
+    $valueFromDocument,
+    function shouldUpdate(valueFromDocument) {
+      if (compareValues(localValue, valueFromDocument))
+        dirty = false
+
+      return !dirty
+    }
+  )
 
   return /** @type const */ ([$value, setValue])
 
@@ -35,4 +41,19 @@ export function useFieldValue({
 
     patchDocumentDebounced({ document, fieldType: field.type, path: $path.get(), value })
   }
+}
+
+/**
+ * @template X
+ * @param {Signal<X>} signal
+ * @param {(newValue: X, oldValue: X) => Boolean} shouldUpdate
+ */
+export function useConditionalDerive(signal, shouldUpdate) {
+  let oldValue = signal.get()
+  return signal.derive(newValue => {
+    if (shouldUpdate(newValue, oldValue))
+      oldValue = newValue
+
+    return oldValue
+  })
 }

--- a/packages/cms/client/form/richTextEditor/RichTextEditor.js
+++ b/packages/cms/client/form/richTextEditor/RichTextEditor.js
@@ -189,7 +189,7 @@ RichTextEditor.toJson = function toJson(doc) {
 RichTextEditor.fromJson = function fromJson(schema, json) {
   if (!json) return json
 
-  const checkedContent = json.content.map(x =>
+  const checkedContent = json.content?.map(x =>
     x.type in schema.nodes ? x : { type: 'unknown', attrs: { node: x } }
   )
   return Node.fromJSON(schema, { ...json, content: checkedContent })

--- a/packages/cms/client/form/richTextEditor/RichTextEditor.js
+++ b/packages/cms/client/form/richTextEditor/RichTextEditor.js
@@ -75,7 +75,7 @@ export function RichTextEditor({ id, initialValue, $steps, synchronize, onChange
       //     }))
       //   })
       const stepsWereSent = tryToSynchronize(view)
-      if (!stepsWereSent && newState.doc.attrs.lastEditClientId === context.clientId) {
+      if (transaction.docChanged && !stepsWereSent && newState.doc.attrs.lastEditClientId === context.clientId) {
         onChange(view.state.doc)
       }
     },

--- a/packages/cms/client/form/richTextEditor/RichTextEditor.js
+++ b/packages/cms/client/form/richTextEditor/RichTextEditor.js
@@ -17,7 +17,7 @@ import { nodeView, schemaPlugins } from './schema.js'
 const { div } = tags
 
 /**
- * @typedef {(data: { clientId, steps: readonly Step[], version: number, value: Node }) => {
+ * @typedef {(data: { clientId, steps: readonly Step[], version: number }) => {
  *   result: Promise<{ success: boolean }>,
  *   abort(reason?: string): void,
  * }} Synchronize
@@ -42,13 +42,14 @@ RichTextEditor.style = css`
 /**
  * @param {{
  *  id: string,
- *  initialValue: { value: Node, version: number },
- *  $steps: Signal<{ steps: Step[], clientIds: Array<number | string> }>,
+ *  initialValue: Node,
+ *  $steps: Signal<{ steps: Step[], clientIds: Array<number | string>, version: number }>,
  *  synchronize: Synchronize,
+ *  onChange(doc: Node): void,
  *  schema: Schema,
  * }} props
  */
-export function RichTextEditor({ id, initialValue, $steps, synchronize, schema }) {
+export function RichTextEditor({ id, initialValue, $steps, synchronize, onChange, schema }) {
   // TODO: show the cursors of other people with an overlay using https://prosemirror.net/docs/ref/#view.EditorView.coordsAtPos
 
   const { tryToSynchronize } = useSynchronization({ synchronize })
@@ -56,12 +57,12 @@ export function RichTextEditor({ id, initialValue, $steps, synchronize, schema }
   const plugins = [
     history(),
     ...createKeymaps({ schema }),
-    collab.collab({ version: initialValue.version, clientID: context.clientId }),
+    collab.collab({ version: initialValue.attrs.version, clientID: context.clientId }),
     ...schemaPlugins(schema),
   ]
   const view = new EditorView(null, {
     attributes: { id },
-    state: EditorState.create({ doc: initialValue.value, schema, plugins, }),
+    state: EditorState.create({ doc: initialValue, schema, plugins, }),
     dispatchTransaction(transaction) {
       const newState = view.state.apply(transaction)
       view.updateState(newState)
@@ -73,7 +74,10 @@ export function RichTextEditor({ id, initialValue, $steps, synchronize, schema }
       //       invert: x.invert(docBeforeChange).toJSON()
       //     }))
       //   })
-      tryToSynchronize(view)
+      const stepsWereSent = tryToSynchronize(view)
+      if (!stepsWereSent && newState.doc.attrs.lastEditClientId === context.clientId) {
+        onChange(view.state.doc)
+      }
     },
     nodeViews: Object.fromEntries(
       Object.entries(schema.nodes).map(([name, node]) =>
@@ -81,10 +85,14 @@ export function RichTextEditor({ id, initialValue, $steps, synchronize, schema }
       )                             // if link does not jump (https://github.com/orgs/community/discussions/139005#discussioncomment-11092579)
     )                               // src/schema.ts line 432
   })
-  const unsubscribe = $steps.subscribe(({ steps, clientIds }) => {
-    view.dispatch(
-      collab.receiveTransaction(view.state, steps, clientIds, { mapSelectionBackward: true })
-    )
+  const unsubscribe = $steps.subscribe(({ steps, clientIds, version }) => { // TODO: rename version to sessionVersion
+    const tr = collab.receiveTransaction(view.state, steps, clientIds, { mapSelectionBackward: true })
+    tr.setDocAttribute('version', version)
+    const [lastEditClientId] = clientIds.slice(-1)
+    if (lastEditClientId) {
+      tr.setDocAttribute('lastEditClientId', lastEditClientId)
+    }
+    view.dispatch(tr)
   })
 
   useOnDestroy(() => {
@@ -112,11 +120,15 @@ function useSynchronization({ synchronize }) {
 
   return { tryToSynchronize }
 
-  /** @param {EditorView} view */
-  async function tryToSynchronize(view, retries = 5) {
+  /**
+   * @param {EditorView} view
+   * @returns {Boolean} Indicating that steps were sent to the server
+   */
+  function tryToSynchronize(view, retries = 5) {
     try {
       const sendable = collab.sendableSteps(view.state)
-      if (!sendable) return
+      if (!sendable)
+        return
 
       if (synchronizationRequest) {
         synchronizationRequest.abort('Aborting: new steps available')
@@ -124,7 +136,7 @@ function useSynchronization({ synchronize }) {
       }
 
       const { clientID, steps, version } = sendable
-      const { result, abort } = synchronize({ clientId: clientID, steps, version, value: view.state.doc })
+      const { result, abort } = synchronize({ clientId: clientID, steps, version })
       let aborted = false
       synchronizationRequest = {
         abort(reason) {
@@ -134,17 +146,27 @@ function useSynchronization({ synchronize }) {
         }
       }
 
-      const { success } = await result
-      synchronizationRequest = null
-      if (aborted) return
-      if (success) return // no need to do anything else, steps will come in via the other channel
+      result
+        .then(({ success }) => {
+          synchronizationRequest = null
+          if (aborted)
+            return
 
-      if (!retries)
-        throw new Error(`Failed to synchronize and no more retries left`)
+          if (success)
+            return // no need to do anything else, steps will come in via the other channel
 
-      console.log('Retrying synchronization')
+          if (!retries)
+            throw new Error(`Failed to synchronize and no more retries left`)
 
-      tryToSynchronize(view, retries - 1)
+          console.log('Retrying synchronization')
+
+          tryToSynchronize(view, retries - 1)
+        })
+        .catch(e => {
+          console.error(e)
+        })
+
+      return true // steps were sent (maybe not successful)
     } catch (e) {
       console.error(e)
     }

--- a/packages/cms/client/form/richTextEditor/schema.js
+++ b/packages/cms/client/form/richTextEditor/schema.js
@@ -237,5 +237,11 @@ schema.link = function link(spec) {
 }
 
 schema.doc = function doc(content) {
-  return { content }
+  return {
+    content,
+    attrs: {
+      version: { default: 0 },
+      lastEditClientId: { default: '' },
+    },
+  }
 }

--- a/packages/cms/client/machinery/useEventSourceAsSignal.js
+++ b/packages/cms/client/machinery/useEventSourceAsSignal.js
@@ -5,23 +5,23 @@ import { context } from '../context.js'
 /**
  * @template T
  * @param {({ args: any[] } | { argsSignal: Signal<any[]> }) &
- *   { channel: string, events: Array<string>, initialValue?: T }
+ *   { channel: string, events: Array<string>, initialValue?: T, info?: any }
  * } params
  * @returns {Signal<T | { event: string, data: any }>}
  */
 export function useEventSourceAsSignal(params) {
-  const { channel, events, initialValue = null } = params
+  const { channel, events, initialValue = null, info = null } = params
 
   const argsIsSignal = 'argsSignal' in params
 
   const [$signal, setValue] = createSignal(initialValue)
 
   const args = argsIsSignal ? params.argsSignal.get() : params.args
-  let unsubscribeEvents = subscribeToEvents(channel, args, events, setValue)
+  let unsubscribeEvents = subscribeToEvents(channel, args, info, events, setValue)
 
   const unsubscribeSignal = argsIsSignal && params.argsSignal.subscribe(args => {
     unsubscribeEvents()
-    unsubscribeEvents = subscribeToEvents(channel, args, events, setValue)
+    unsubscribeEvents = subscribeToEvents(channel, args, info, events, setValue)
   })
 
   useOnDestroy(() => {
@@ -32,6 +32,6 @@ export function useEventSourceAsSignal(params) {
   return $signal
 }
 
-function subscribeToEvents(channel, args, events, callback) {
-  return context.events.subscribe(channel, args, events, callback)
+function subscribeToEvents(channel, args, info, events, callback) {
+  return context.events.subscribe(channel, args, info, events, callback)
 }

--- a/packages/cms/client/routeMap.js
+++ b/packages/cms/client/routeMap.js
@@ -17,7 +17,7 @@ export const routeMap = asRouteMap({
           data: handler(x => x.documents.single.patch),
 
           richText: {
-            path: 'rich-text/:encodedFieldPath',
+            path: 'rich-text',
             data: handler(x => x.documents.single.richText.post),
           },
         }

--- a/packages/cms/server/documents.js
+++ b/packages/cms/server/documents.js
@@ -23,7 +23,7 @@ export function createDocumentsHandler({ databaseActions, streams }) {
   } = databaseActions.documents
 
   const historyHandler = createHistoryHandler({ databaseActions })
-  const richTextHandler = createRichTextHandler({ databaseActions, streams, patchDocument })
+  const richTextHandler = createRichTextHandler({ streams })
 
   return {
     richText: richTextHandler,

--- a/packages/cms/server/documents/history.js
+++ b/packages/cms/server/documents/history.js
@@ -50,7 +50,7 @@ function createStringDetails(change, details) {
  */
 function createRichTextDetails(change, details, info) {
   return {
-    steps: details.steps ? details.steps.concat(info.steps) : info.steps,
+
   }
 }
 

--- a/packages/cms/server/requestHandlers.js
+++ b/packages/cms/server/requestHandlers.js
@@ -69,7 +69,7 @@ export function createRequestHandlers({ basePath, documents, images, streams }) 
           withRequestJsonBody(req, (body, e) => {
 
             // TODO: error handling
-            const { channel, args } = body
+            const { channel, args, info } = body
 
             // TODO: incorrect args for channel handling
 
@@ -80,7 +80,7 @@ export function createRequestHandlers({ basePath, documents, images, streams }) 
 
             const { action } = params
             if (action === 'subscribe')
-              eventStreams.subscribe(connectId, args)
+              eventStreams.subscribe(connectId, args, info)
             if (action === 'unsubscribe')
               eventStreams.unsubscribe(connectId, args)
 

--- a/packages/ui/signal.js
+++ b/packages/ui/signal.js
@@ -11,6 +11,10 @@ export class Signal {
   /** @returns {T} */
   get() { return null }
 
+  // TODO: both callbacks accept `oldValue`, this is a perfomance penalty to derived signals
+  //       I think we should make a separate set of methods if `oldValue` is used so that the
+  //       performance penalty is only paid when needed.
+
   /** @param {(value: T, oldValue: T) => void} callback @returns {() => void} */
   subscribe(callback){ return null }
 

--- a/packages/ui/signal.js
+++ b/packages/ui/signal.js
@@ -17,7 +17,7 @@ export class Signal {
   /** @param {(value: T, oldValue: T) => void} callback @returns {() => void} */
   subscribeDirect(callback){ return null }
 
-  /** @template X @param {(value: T, previous?: X) => X} f @returns {Signal<X>} */
+  /** @template X @param {(value: T) => X} f @returns {Signal<X>} */
   derive(f) { return null }
 
   /** @returns {string} */


### PR DESCRIPTION
This won from another version where I tried to use the steps to create a diff (https://github.com/EECOLOR/no-build-poc/tree/refs/tags/history-rich-text).

That version used the steps created by prose-mirror to determine what changed. This was too complex and too fine-grained to be useful. On top of that it required the schema and prose-mirror itself to render the result. For history that posed a few problems: rich-text schema might have changed over time, added complexity rendering the history item, special storage needs, ...

This version serializes the value to HTML and uses a diff algorithm (where tags are substituted for unicode characters) to display the changes. This makes handling of different history items more universal and easier to reason about.